### PR TITLE
Update `julia` install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Pumas or DeepPumas. Currently supported versions of products are:
 
 ## Installation
 
-Install `julia` via https://julialang.org/downloads/#install_julia and make
-sure that the first option is chosen, which installs the `juliaup` version
+Install `julia` via https://julialang.org/install/, which installs the `juliaup` version
 manager. This is essential for the product manager to work.
 
 Next run one of the following commands in a terminal window to install the


### PR DESCRIPTION
The links have changed, downloads is now for manual installers, while install is for the juliaup manager. We need the latter.