### PR TITLE
Expand Windows installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,24 @@ product manager package:
 
 **Windows Users**
 
+The command you have to run depends on the terminal application you are using.
+
+In the Command Prompt (`cmd.exe`) you have to run:
+
+```shell
+julia --project=@PumasProductManager -i -e "import Pkg; Pkg.add(url=\"https://github.com/PumasAI/PumasProductManager.jl\"); import PumasProductManager"
 ```
+
+In the Windows Powershell (`powershell.exe`) you have to run:
+
+```shell
 julia --project=@PumasProductManager -i -e 'import Pkg; Pkg.add(url=\"https://github.com/PumasAI/PumasProductManager.jl\"); import PumasProductManager'
+```
+
+In the Powershell (`pwsh.exe`) you have to run:
+
+```shell
+julia --project=@PumasProductManager -i -e 'import Pkg; Pkg.add(url="https://github.com/PumasAI/PumasProductManager.jl"); import PumasProductManager'
 ```
 
 **macOS and Linux Users**


### PR DESCRIPTION
I had a spare laptop with Windows laying around and tried the Windows installation instructions. I noticed that depending on the terminal application one has to use different installation commands (none of them could be reused in multiple terminals, each terminal apparently has a different syntax for escaping quotes).

IMO these differences make the installation quite confusing and error prone, so I'd suggest a different approach: Instead of a single-line command, starting the Julia REPL first and then executing a - possibly single-line - command in the Julia REPL. This should work on all operating systems in the same way.