### PR TITLE
Hide preview releases in `pumas list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,8 @@ Pumas or DeepPumas. Currently supported versions of products are:
 
 - `Pumas@2.6.0`
 - `Pumas@2.6.1`
-- `Pumas@2.7.0-prerelease`
 - `DeepPumas@0.8.0`
 - `DeepPumas@0.8.1`
-
-*Versions labelled as `prerelease` are considered preview releases and should
-not be used for production work. They are provided for testing purposes only.*
 
 > [!IMPORTANT]
 >
@@ -44,7 +40,6 @@ DeepPumas@0.8.0
 DeepPumas@0.8.1
 Pumas@2.6.0
 Pumas@2.6.1
-Pumas@2.7.0-prerelease
 ```
 
 Then initialize any of the listed products to install them, for example:

--- a/src/PkgREPL.jl
+++ b/src/PkgREPL.jl
@@ -31,13 +31,15 @@ function _define_specs()
         short_name = "ls",
         api = PumasProductManager.list,
         arg_count = 0 => 0,
+        option_spec = [Pair{Symbol,Any}[:name=>"all", :api=>:all_products=>true]],
         description = "list available Pumas products",
         help = md"""
-               ```plaintext
-               pkg> pumas list
-               ```
+                   pumas [ls|list] [--all]
 
                List the available Pumas products and their versions.
+
+               All products (including preview releases not intended for production work)
+               can be listed by passing `--all`.
                """,
     )
     init_spec = Pkg.REPLMode.CommandSpec(
@@ -48,9 +50,7 @@ function _define_specs()
         completions = complete_init,
         description = "initialize a new Pumas project",
         help = md"""
-               ```plaintext
-               pkg> pumas init <product> [<path>]
-               ```
+                   pumas init <product> [<path>]
 
                Initialize a new Pumas product installation at the provided path.
                Use `.` for the current path. The path cannot contain a

--- a/src/PumasProductManager.jl
+++ b/src/PumasProductManager.jl
@@ -83,29 +83,28 @@ end
 # the user runs it when listing or initializing products.
 products_path()
 
-function products()
-    environment_path = joinpath(products_path(), "environments")
-    return readdir(environment_path)
+function products_environments_path()
+    return joinpath(products_path(), "environments")
 end
 
-function product_metadata()
-    ids = products()
-    return map(ids) do id
-        name, version = split(id, "@"; limit = 2)
-        return name, VersionNumber(version)
-    end
-end
-
-function list(io = stdout)
-    for (name, version) in sort(product_metadata())
-        println(io, "$name@$version") # TODO: better formatting.
+function list(io = stdout; all_products::Bool = false)
+    for product in readdir(products_environments_path())
+        name_version = split(product, '@'; limit = 2)
+        if length(name_version) != 2
+            @error "invalid product name" product
+        end
+        name = name_version[begin]
+        version = VersionNumber(name_version[end])
+        if all_products || (version.prerelease == () && version.build == ())
+            println(io, name, "@", version)
+        end
     end
 end
 
 has_juliaup() = success(`juliaup --version`)
 
 function init(product::String, path::Union{String,Nothing} = nothing)
-    product in products() || error("invalid product: $product")
+    isdir(products_environments_path(), product) || error("invalid product: ", product)
 
     # We require `juliaup` to be able to install multiple products that may
     # need different Julia versions.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,32 +1,45 @@
 import PumasProductManager
+import Pkg
 using Test
 
 @testset "PumasProductManager" begin
     # NOTE: update whenever new versions are released.
-    expected_versions = [
-        "DeepPumas@0.8.0",
-        "DeepPumas@0.8.1",
-        "Pumas@2.6.0",
-        "Pumas@2.6.1",
-        "Pumas@2.7.0-prerelease",
-    ]
+    expected_releases = ["DeepPumas@0.8.0", "DeepPumas@0.8.1", "Pumas@2.6.0", "Pumas@2.6.1"]
+    expected_prereleases = ["Pumas@2.7.0-prerelease"]
 
     @testset "Version listing" begin
-        io = IOBuffer()
-        PumasProductManager.list(io)
-        list = String(take!(io))
+        # `PumasProductManager.list`
+        for kwargs in ((;), (; all_products = false), (; all_products = true))
+            io = IOBuffer()
+            PumasProductManager.list(io; kwargs...)
+            expected_versions = if get(kwargs, :all_products, false)
+                sort(vcat(expected_releases, expected_prereleases))
+            else
+                expected_releases
+            end
+            @test collect(eachline(seekstart(io))) == expected_versions
+        end
 
-        for each in expected_versions
-            @test contains(list, each)
+        # Pkg REPL mode
+        mktemp() do f, io
+            redirect_stdout(() -> Pkg.pkg"pumas ls", io)
+            flush(io)
+            @test collect(eachline(f)) == expected_releases
+        end
+        mktemp() do f, io
+            redirect_stdout(() -> Pkg.pkg"pumas ls --all", io)
+            flush(io)
+            @test collect(eachline(f)) ==
+                  sort(vcat(expected_releases, expected_prereleases))
         end
     end
 
-    try
-        mktempdir() do dir
-            @testset "Installation" begin
-                cd(dir) do
-                    withenv("JULIA_PKG_PRECOMPILE_AUTO" => "1") do
-                        for each in expected_versions
+    for each in vcat(expected_releases, expected_prereleases)
+        try
+            mktempdir() do dir
+                @testset "Installation" begin
+                    cd(dir) do
+                        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "1") do
                             PumasProductManager.init(each)
                             PumasProductManager.init(each, each)
                         end
@@ -34,33 +47,24 @@ using Test
                 end
 
                 status = readchomp(`juliaup st`)
-                for each in expected_versions
-                    @test contains(status, each)
+                @test contains(status, each)
+
+                dirs = [joinpath(DEPOT_PATH[1], "environments", each), joinpath(dir, each)]
+                for folder in dirs
+                    @test isfile(folder, "Project.toml")
+                    @test isfile(folder, "Manifest.toml")
                 end
 
-                for each in expected_versions
-                    dirs =
-                        [joinpath(DEPOT_PATH[1], "environments", each), joinpath(dir, each)]
-                    for folder in dirs
-                        contents = readdir(folder)
-                        @test "Project.toml" in contents
-                        @test "Manifest.toml" in contents
-                    end
-                end
-
-                for each in expected_versions
-                    product, _ = split(each, "@"; limit = 2)
-                    file = joinpath(@__DIR__, "$product.jl")
-                    channel = "+$each"
-                    cmd = `julia $channel $file`
-                    @test contains(readchomp(cmd), ":success")
-                end
+                product, _ = split(each, "@"; limit = 2)
+                file = joinpath(@__DIR__, "$product.jl")
+                channel = "+$each"
+                cmd = `julia $channel $file`
+                @test contains(readchomp(cmd), ":success")
             end
-        end
-    finally
-        for each in expected_versions
+        finally
             @test success(`juliaup rm $each`)
         end
-        @test success(`juliaup rm PumasProductManager`)
     end
+
+    @test success(`juliaup rm PumasProductManager`)
 end


### PR DESCRIPTION
As these are not intended for production work. They can be listed if desired with an `--all` flag (similar to existing flags for `rm` etc. in Pkg).

Ref https://github.com/PumasAI/pumas-products-bundler/issues/110#issue-3290311648